### PR TITLE
non-mutating mutable collection conformance

### DIFF
--- a/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift
+++ b/stdlib/private/StdlibCollectionUnittest/LoggingWrappers.swift
@@ -433,7 +433,7 @@ extension LoggingMutableCollection: MutableCollection {
    }
    
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     MutableCollectionLog._withUnsafeMutableBufferPointerIfSupported[selfType] += 1
     let result = try base._withUnsafeMutableBufferPointerIfSupported(body)
@@ -636,7 +636,7 @@ extension BufferAccessLoggingMutableCollection: MutableCollection {
   }
 
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     Log._withUnsafeMutableBufferPointerIfSupported[selfType] += 1
     let result = try base._withUnsafeMutableBufferPointerIfSupported(body)

--- a/stdlib/public/core/Array.swift
+++ b/stdlib/public/core/Array.swift
@@ -1271,11 +1271,11 @@ extension Array: RangeReplaceableCollection {
 
   @inlinable
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
-      return try body(&bufferPointer)
+      return try body(bufferPointer)
     }
   }
 

--- a/stdlib/public/core/ArraySlice.swift
+++ b/stdlib/public/core/ArraySlice.swift
@@ -1066,11 +1066,11 @@ extension ArraySlice: RangeReplaceableCollection {
 
   @inlinable
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
-      return try body(&bufferPointer)
+      return try body(bufferPointer)
     }
   }
 

--- a/stdlib/public/core/BufferMutableCollection.swift
+++ b/stdlib/public/core/BufferMutableCollection.swift
@@ -1,0 +1,129 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the Swift.org open source project
+//
+// Copyright (c) 2014 - 2017 Apple Inc. and the Swift project authors
+// Licensed under Apache License v2.0 with Runtime Library Exception
+//
+// See https://swift.org/LICENSE.txt for license information
+// See https://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
+//
+//===----------------------------------------------------------------------===//
+
+public protocol _BufferMutableCollection: MutableCollection
+{
+  override subscript(position: Index) -> Element { get nonmutating set }
+
+  subscript(bounds: Range<Index>) -> Slice<Self> { get nonmutating set }
+  
+  override nonmutating func partition(
+    by belongsInSecondPartition: (Element) throws -> Bool
+  ) rethrows -> Index
+  
+  override nonmutating func swapAt(_ i: Index, _ j: Index)
+
+  nonmutating func _withUnsafeMutableBufferPointerIfSupported<R>(
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
+  ) rethrows -> R?
+}
+
+extension _BufferMutableCollection
+{
+  @inlinable
+  public nonmutating func _withUnsafeMutableBufferPointerIfSupported<R>(
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
+  ) rethrows -> R? {
+    return nil
+  }
+}
+
+/* From CollectionAlgorithms.swift.gyb */
+
+extension _BufferMutableCollection
+  where Self: BidirectionalCollection {
+  @inlinable
+  public nonmutating func partition(
+    by belongsInSecondPartition: (Element) throws -> Bool
+  ) rethrows -> Index {
+    var ref = self
+    return try ref._partition(by: belongsInSecondPartition)
+  }
+}
+
+extension _BufferMutableCollection
+  where Self: RandomAccessCollection {
+  @inlinable
+  public nonmutating func shuffle<T: RandomNumberGenerator>(
+    using generator: inout T
+  ) {
+    var ref = self
+    ref._shuffle(using: &generator)
+  }
+
+  @inlinable
+  public mutating func shuffle() {
+    var g = SystemRandomNumberGenerator()
+    shuffle(using: &g)
+  }
+}
+
+/* Adapted from Sort.swift */
+
+extension _BufferMutableCollection
+  where Self: RandomAccessCollection,
+        Element: Comparable {
+  @inlinable
+  public nonmutating func sort() {
+    sort(by: <)
+  }
+}
+
+/* Adapted from Sort.swift */
+
+extension _BufferMutableCollection
+  where Self: RandomAccessCollection {
+  @inlinable
+  public nonmutating func sort(
+    by areInIncreasingOrder: (Element, Element) throws -> Bool
+  ) rethrows {
+    var ref = self
+    try ref._introSort(
+      within: startIndex..<endIndex,
+      by: areInIncreasingOrder
+    )
+  }
+}
+
+/* From Reverse.swift */
+
+extension _BufferMutableCollection
+  where Self: BidirectionalCollection {
+  @inlinable
+  public nonmutating func reverse() {
+    var ref = self
+    ref._reverse()
+  }
+}
+
+/* From Range.swift */
+
+extension _BufferMutableCollection {
+  public subscript<R: RangeExpression>(r: R) -> Slice<Self>
+    where R.Bound == Index {
+    get {
+      return self[r.relative(to: self)]
+    }
+    nonmutating set {
+      self[r.relative(to: self)] = newValue
+    }
+  }
+
+  public subscript(x: UnboundedRange) -> Slice<Self> {
+    get {
+      return self[startIndex...]
+    }
+    nonmutating set {
+      self[startIndex...] = newValue
+    }
+  }
+}

--- a/stdlib/public/core/CMakeLists.txt
+++ b/stdlib/public/core/CMakeLists.txt
@@ -36,6 +36,7 @@ set(SWIFTLIB_ESSENTIAL
   BridgeObjectiveC.swift
   BridgeStorage.swift
   BridgingBuffer.swift
+  BufferMutableCollection.swift
   Builtin.swift
   BuiltinMath.swift.gyb
   Character.swift

--- a/stdlib/public/core/CollectionAlgorithms.swift
+++ b/stdlib/public/core/CollectionAlgorithms.swift
@@ -328,6 +328,13 @@ extension MutableCollection where Self : BidirectionalCollection {
       return index(startIndex, offsetBy: numericCast(offset))
     }
 
+    return try _partition(by: belongsInSecondPartition)
+  }
+
+  @inlinable
+  mutating func _partition(
+    by belongsInSecondPartition: (Element) throws -> Bool
+  ) rethrows -> Index {
     var lo = startIndex
     var hi = endIndex
 
@@ -443,6 +450,13 @@ extension MutableCollection where Self : RandomAccessCollection {
   ///   Swift.
   @inlinable
   public mutating func shuffle<T: RandomNumberGenerator>(
+    using generator: inout T
+    ) {
+      _shuffle(using: &generator)
+  }
+
+  @inlinable
+  mutating func _shuffle<T: RandomNumberGenerator>(
     using generator: inout T
   ) {
     let count = self.count

--- a/stdlib/public/core/ContiguousArray.swift
+++ b/stdlib/public/core/ContiguousArray.swift
@@ -915,11 +915,11 @@ extension ContiguousArray: RangeReplaceableCollection {
 
   @inlinable
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     return try withUnsafeMutableBufferPointer {
       (bufferPointer) -> R in
-      return try body(&bufferPointer)
+      return try body(bufferPointer)
     }
   }
 

--- a/stdlib/public/core/GroupInfo.json
+++ b/stdlib/public/core/GroupInfo.json
@@ -169,6 +169,7 @@
     "Pointer.swift",
     "UnsafePointer.swift",
     "UnsafeRawPointer.swift",
+    "BufferMutableCollection.swift",
     "UnsafeBufferPointer.swift",
     "UnsafeRawBufferPointer.swift"
   ],

--- a/stdlib/public/core/MutableCollection.swift
+++ b/stdlib/public/core/MutableCollection.swift
@@ -177,7 +177,7 @@ where SubSequence: MutableCollection
   /// same algorithm on `body`\ 's argument lets you trade safety for
   /// speed.
   mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R?
 }
 
@@ -185,7 +185,7 @@ where SubSequence: MutableCollection
 extension MutableCollection {
   @inlinable
   public mutating func _withUnsafeMutableBufferPointerIfSupported<R>(
-    _ body: (inout UnsafeMutableBufferPointer<Element>) throws -> R
+    _ body: (UnsafeMutableBufferPointer<Element>) throws -> R
   ) rethrows -> R? {
     return nil
   }

--- a/stdlib/public/core/Reverse.swift
+++ b/stdlib/public/core/Reverse.swift
@@ -24,6 +24,11 @@ extension MutableCollection where Self: BidirectionalCollection {
   ///   collection.
   @inlinable // protocol-only
   public mutating func reverse() {
+    _reverse()
+  }
+
+  @inlinable // protocol-only
+  mutating func _reverse() {
     if isEmpty { return }
     var f = startIndex
     var l = index(before: endIndex)

--- a/stdlib/public/core/UnsafeBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeBufferPointer.swift.gyb
@@ -14,6 +14,7 @@
 % for mutable in (True, False):
 %  Self = 'UnsafeMutableBufferPointer' if mutable else 'UnsafeBufferPointer'
 %  Mutable = 'Mutable' if mutable else ''
+%  BufferMutable = '_BufferMutableCollection, Mutable' if mutable else ''
 /// A nonowning collection interface to a buffer of ${Mutable.lower()}
 /// elements stored contiguously in memory.
 ///
@@ -117,7 +118,7 @@ extension Unsafe${Mutable}BufferPointer: Sequence {
   }
 }
 
-extension Unsafe${Mutable}BufferPointer: ${Mutable}Collection, RandomAccessCollection {
+extension Unsafe${Mutable}BufferPointer: ${BufferMutable}Collection, RandomAccessCollection {
   public typealias Index = Int
   public typealias Indices = Range<Int>
 

--- a/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
+++ b/stdlib/public/core/UnsafeRawBufferPointer.swift.gyb
@@ -15,6 +15,7 @@
 % for mutable in (True, False):
 %  Self = 'UnsafeMutableRawBufferPointer' if mutable else 'UnsafeRawBufferPointer'
 %  Mutable = 'Mutable' if mutable else ''
+%  BufferMutable = '_BufferMutableCollection, Mutable' if mutable else ''
 
 /// A ${Mutable.lower()} nonowning collection interface to the bytes in a
 /// region of memory.
@@ -147,7 +148,7 @@ extension Unsafe${Mutable}RawBufferPointer: Sequence {
   }
 }
 
-extension Unsafe${Mutable}RawBufferPointer: ${Mutable}Collection {
+extension Unsafe${Mutable}RawBufferPointer: ${BufferMutable}Collection {
   // TODO: Specialize `index` and `formIndex` and
   // `_failEarlyRangeCheck` as in `UnsafeBufferPointer`.
   public typealias Element = UInt8

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -272,7 +272,7 @@ UnsafeMutableRawBufferPointerTestSuite.test("changeElementViaBuffer") {
   let uint8Ptr = allocated.initializeMemory(as: UInt8.self, repeating: 1, count: count)
   uint8Ptr[count-1] = UInt8.max
 
-  var buffer = UnsafeMutableRawBufferPointer(start: allocated, count: count - 1)
+  let buffer = UnsafeMutableRawBufferPointer(start: allocated, count: count - 1)
 
   buffer[1] = 0
   expectEqual(1, buffer[0])
@@ -293,6 +293,37 @@ UnsafeMutableRawBufferPointerTestSuite.test("changeElementViaBuffer") {
   expectEqual(1, uint8Ptr[1])
   expectEqual(1, uint8Ptr[2])
   expectEqual(UInt8.max, uint8Ptr[count-1])
+
+  buffer.sort(by: >)
+  expectEqual(1, buffer[0])
+  expectEqual(1, buffer[1])
+  expectEqual(0, buffer[2])
+
+  expectEqual(1, uint8Ptr[0])
+  expectEqual(1, uint8Ptr[1])
+  expectEqual(0, uint8Ptr[2])
+  expectEqual(UInt8.max, uint8Ptr[count-1])
+
+  let p = buffer.partition(by: { $0%2 == 1 })
+  expectEqual(p, 1)
+  expectEqual(0, buffer[0])
+  expectEqual(1, buffer[1])
+  expectEqual(1, buffer[2])
+
+  expectEqual(0, uint8Ptr[0])
+  expectEqual(1, uint8Ptr[1])
+  expectEqual(1, uint8Ptr[2])
+  expectEqual(UInt8.max, uint8Ptr[count-1])
+
+  buffer.reverse()
+  expectEqual(1, buffer[0])
+  expectEqual(1, buffer[1])
+  expectEqual(0, buffer[2])
+
+  expectEqual(1, uint8Ptr[0])
+  expectEqual(1, uint8Ptr[1])
+  expectEqual(0, uint8Ptr[2])
+  expectEqual(UInt8.max, uint8Ptr[count-1])
 }
 
 UnsafeMutableBufferPointerTestSuite.test("changeElementViaBuffer") {
@@ -302,7 +333,7 @@ UnsafeMutableBufferPointerTestSuite.test("changeElementViaBuffer") {
   allocated.initialize(repeating: 1.0, count: count)
   allocated[count-1] = -1.0
 
-  var buffer = UnsafeMutableBufferPointer(start: allocated, count: count - 1)
+  let buffer = UnsafeMutableBufferPointer(start: allocated, count: count - 1)
 
   buffer[1] = 0.0
   expectEqual(1.0, buffer[0])
@@ -322,6 +353,37 @@ UnsafeMutableBufferPointerTestSuite.test("changeElementViaBuffer") {
   expectEqual(0.0, allocated[0])
   expectEqual(1.0, allocated[1])
   expectEqual(1.0, allocated[2])
+  expectEqual(-1.0, allocated[count-1])
+
+  buffer.sort(by: >)
+  expectEqual(1.0, buffer[0])
+  expectEqual(1.0, buffer[1])
+  expectEqual(0.0, buffer[2])
+
+  expectEqual(1.0, allocated[0])
+  expectEqual(1.0, allocated[1])
+  expectEqual(0.0, allocated[2])
+  expectEqual(-1.0, allocated[count-1])
+
+  let p = buffer.partition(by: { !$0.isZero })
+  expectEqual(p, 1)
+  expectEqual(0.0, buffer[0])
+  expectEqual(1.0, buffer[1])
+  expectEqual(1.0, buffer[2])
+
+  expectEqual(0.0, allocated[0])
+  expectEqual(1.0, allocated[1])
+  expectEqual(1.0, allocated[2])
+  expectEqual(-1.0, allocated[count-1])
+
+  buffer.reverse()
+  expectEqual(1.0, buffer[0])
+  expectEqual(1.0, buffer[1])
+  expectEqual(0.0, buffer[2])
+
+  expectEqual(1.0, allocated[0])
+  expectEqual(1.0, allocated[1])
+  expectEqual(0.0, allocated[2])
   expectEqual(-1.0, allocated[count-1])
 }
 
@@ -841,11 +903,7 @@ UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("subscript/${R
   defer { deallocateFor${Raw}Buffer(
       sliceMemory, count: replacementValues.count) }
 
-% if RangeName == 'range':
   let buffer = SubscriptSetTest.create${SelfName}(from: memory)
-% else:
-  var buffer = SubscriptSetTest.create${SelfName}(from: memory)
-% end
 
 %     if IsRaw:
   // A raw buffer pointer has debug bounds checks on indices, and
@@ -956,6 +1014,19 @@ UnsafeMutableBufferPointerTestSuite.test("nonmutating-swapAt-withARC") {
   expectEqual(Array(buffer), ["2", "1", "0"])
 }
 % end
+
+UnsafeMutable${'Raw' if IsRaw else ''}BufferPointerTestSuite.test("withUMBPIfSupported") {
+% if IsRaw:
+  let buffer = UnsafeMutableRawBufferPointer.allocate(count: 3)
+% else:
+  let buffer = UnsafeMutableBufferPointer<Int>.allocate(capacity: 3)
+% end
+  defer { buffer.deallocate() }
+
+  if let _ = buffer._withUnsafeMutableBufferPointerIfSupported({ _ in expectUnreachable() }) {
+  expectUnreachable()
+  }
+}
 
 % end # SelfName
 

--- a/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
+++ b/validation-test/stdlib/UnsafeBufferPointer.swift.gyb
@@ -324,6 +324,9 @@ UnsafeMutableRawBufferPointerTestSuite.test("changeElementViaBuffer") {
   expectEqual(1, uint8Ptr[1])
   expectEqual(0, uint8Ptr[2])
   expectEqual(UInt8.max, uint8Ptr[count-1])
+
+  buffer[0...1] = buffer[1...]
+  expectEqual(buffer[1], buffer[2])
 }
 
 UnsafeMutableBufferPointerTestSuite.test("changeElementViaBuffer") {
@@ -385,6 +388,9 @@ UnsafeMutableBufferPointerTestSuite.test("changeElementViaBuffer") {
   expectEqual(1.0, allocated[1])
   expectEqual(0.0, allocated[2])
   expectEqual(-1.0, allocated[count-1])
+
+  buffer[0...1] = buffer[1...]
+  expectEqual(buffer[1], buffer[2])
 }
 
 let bufCount = 4


### PR DESCRIPTION
<!-- What's in this pull request? -->
In the review of [SE-0237](https://forums.swift.org/t/review-of-se-0237-introduce-contiguous-collection-protocols/18069/3), I suggested giving the `UnsafeMutable*BufferPointer` types a non-mutating conformance to `MutableCollection`. Here's one, quickly assembled and mostly tested.

<!--
Before merging this pull request, you must run the Swift continuous integration tests.
For information about triggering CI builds via @swift-ci, see:
https://github.com/apple/swift/blob/master/docs/ContinuousIntegration.md#swift-ci

Thank you for your contribution to Swift!
-->